### PR TITLE
Update NetworkStatusResponse structure

### DIFF
--- a/src/SocketServer.cpp
+++ b/src/SocketServer.cpp
@@ -71,6 +71,9 @@ static const int DefaultWiFiChannel = 6;
 
 static const int MaxAPConnections = 4;
 
+static uint32_t numWifiReconnects = 0;
+static bool usingDhcpc = false;
+
 // Global data
 
 static volatile int currentSsid = -1;
@@ -175,6 +178,12 @@ static void HandleWiFiEvent(void* arg, esp_event_base_t event_base,
 			default:
 				wifiEvt = STATION_CONNECT_FAIL;
 				break;
+		}
+		if (disconnected->reason != WIFI_REASON_ASSOC_LEAVE)
+		{
+			// The disconnection was not triggered by an explicit disconnection command
+			// by RRF, and will cause reconnection attempts. Count them here.
+			numWifiReconnects++;
 		}
 	} else if (event_base == WIFI_EVENT && (event_id == WIFI_EVENT_STA_STOP || event_id == WIFI_EVENT_AP_STOP)) {
 		wifiEvt = WIFI_IDLE;
@@ -310,6 +319,10 @@ void ConnectPoll(void* data)
 
 					debugPrint("Connected to AP\n");
 					currentState = WiFiState::connected;
+					break;
+
+				case STATION_CONNECTING:
+					// Do nothing
 					break;
 
 				default:
@@ -584,7 +597,8 @@ pre(currentState == WiFiState::idle)
 
 	// On Arduino core, gateway and subnet is ignored
 	// if IP address is not specified.
-	if (wp.ip) {
+	if (wp.ip)
+	{
 		tcpip_adapter_ip_info_t ip_info;
 		ip_info.ip.addr = wp.ip;
 		ip_info.gw.addr = wp.gateway;
@@ -595,7 +609,10 @@ pre(currentState == WiFiState::idle)
 			ip_info.netmask.addr = wp.netmask;
 		}
 		tcpip_adapter_set_ip_info(TCPIP_ADAPTER_IF_STA, &ip_info);
-	} else {
+	}
+	else
+	{
+		usingDhcpc = true;
 		tcpip_adapter_dhcpc_start(TCPIP_ADAPTER_IF_STA);
 	}
 
@@ -699,6 +716,7 @@ void StartAccessPoint()
 
 				if (res == ESP_OK) {
 					debugPrintf("Starting AP %s with password \"%s\"\n", apData.ssid, apData.password);
+					currentSsid = WirelessConfigurationMgr::AP;
 					res = esp_wifi_start();
 				}
 
@@ -766,6 +784,57 @@ void SendResponse(int32_t response)
 	{
 		hspi.transferDwords(transferBuffer, nullptr, NumDwords((size_t)response));
 	}
+}
+
+WiFiAuth EspAuthModeToWiFiAuth(wifi_auth_mode_t authmode)
+{
+	WiFiAuth res = WiFiAuth::UNKNOWN;
+
+	switch (authmode)
+	{
+	case WIFI_AUTH_OPEN:
+		res = WiFiAuth::OPEN;
+		break;
+
+	case WIFI_AUTH_WEP:
+		res = WiFiAuth::WEP;
+		break;
+
+	case WIFI_AUTH_WPA_PSK:
+		res = WiFiAuth::WPA_PSK;
+		break;
+
+	case WIFI_AUTH_WPA2_PSK:
+		res = WiFiAuth::WPA2_PSK;
+		break;
+
+	case WIFI_AUTH_WPA_WPA2_PSK:
+		res = WiFiAuth::WPA_WPA2_PSK;
+		break;
+
+	case WIFI_AUTH_WPA2_ENTERPRISE:
+		res = WiFiAuth::WPA2_ENTERPRISE;
+		break;
+
+	case WIFI_AUTH_WPA3_PSK:
+		res = WiFiAuth::WPA3_PSK;
+		break;
+
+	case WIFI_AUTH_WPA2_WPA3_PSK:
+		res = WiFiAuth::WPA2_WPA3_PSK;
+		break;
+
+#ifndef ESP8266
+	case WIFI_AUTH_WAPI_PSK:
+		res = WiFiAuth::WAPI_PSK;
+		break;
+#endif
+
+	default:
+		break;
+	}
+
+	return res;
 }
 
 // This is called when the SAM is asking to transfer data
@@ -844,10 +913,11 @@ void ProcessRequest()
 
 		case NetworkCommand::networkGetStatus:				// get the network connection status
 			{
-				const bool runningAsAp = (currentState == WiFiState::runningAsAccessPoint);
-				const bool runningAsStation = (currentState == WiFiState::connected);
 				NetworkStatusResponse * const response = reinterpret_cast<NetworkStatusResponse*>(transferBuffer);
-				response->freeHeap = esp_get_free_heap_size();
+				memset(response, 0, sizeof(*response));
+
+				response->flashSize = spi_flash_get_chip_size();
+				SafeStrncpy(response->versionText, firmwareVersion, sizeof(response->versionText));
 
 				switch (esp_reset_reason())
 				{
@@ -888,32 +958,13 @@ void ProcessRequest()
 					break;
 				}
 
-				if (runningAsStation) {
-					wifi_ap_record_t ap_info;
-					esp_wifi_sta_get_ap_info(&ap_info);
-					memset(&ap_info, 0, sizeof(ap_info));
-					response->rssi = ap_info.rssi;
-					response->numClients = 0;
-					esp_wifi_get_mac(WIFI_IF_STA, response->macAddress);
-					tcpip_adapter_ip_info_t ip_info;
-					tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ip_info);
-					response->ipAddress = ip_info.ip.addr;
-				} else if (runningAsAp) {
-					wifi_sta_list_t sta_list;
-					memset(&sta_list, 0, sizeof(sta_list));
-					esp_wifi_ap_get_sta_list(&sta_list);
+				SafeStrncpy(response->hostName, webHostName, sizeof(response->hostName));
 
-					response->numClients = sta_list.num;
-					response->rssi = 0;
-					esp_wifi_get_mac(WIFI_IF_AP, response->macAddress);
-					tcpip_adapter_ip_info_t ip_info;
-					tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ip_info);
-					response->ipAddress = ip_info.ip.addr;
-				} else {
-					response->ipAddress = 0;
-				}
-
-				response->flashSize = spi_flash_get_chip_size();
+#ifdef ESP8266
+				response->clockReg = REG(SPI_CLOCK(MSPI));
+#else
+				response->clockReg = SPI_LL_GET_HW(MSPI)->clock.val;
+#endif
 
 				wifi_ps_type_t ps = WIFI_PS_NONE;
 				esp_wifi_get_ps(&ps);
@@ -931,34 +982,89 @@ void ProcessRequest()
 					break;
 				}
 
-				uint8_t EspWiFiPhyMode = 0;
-				esp_wifi_get_protocol(WIFI_IF_STA, &EspWiFiPhyMode);
+				const bool runningAsAp = (currentState == WiFiState::runningAsAccessPoint);
+				const bool runningAsStation = (currentState == WiFiState::connected);
 
-				if (EspWiFiPhyMode | WIFI_PROTOCOL_11N) {
-					response->phyMode = static_cast<int>(EspWiFiPhyMode::N);
-				} else if (EspWiFiPhyMode | WIFI_PROTOCOL_11G) {
-					response->phyMode = static_cast<int>(EspWiFiPhyMode::G);
-				} else if (EspWiFiPhyMode | WIFI_PROTOCOL_11B) {
-					response->phyMode = static_cast<int>(EspWiFiPhyMode::B);
+				response->rssi = INT8_MIN;
+				response->numReconnects = numWifiReconnects;
+				response->usingDhcpc = usingDhcpc;
+
+				if (runningAsAp || runningAsStation)
+				{
+					esp_wifi_get_mac(runningAsStation ? WIFI_IF_STA : WIFI_IF_AP, response->macAddress);
+
+					if (runningAsStation)
+					{
+						wifi_ap_record_t ap_info;
+						memset(&ap_info, 0, sizeof(ap_info));
+						esp_wifi_sta_get_ap_info(&ap_info);
+						response->rssi = ap_info.rssi;
+						response->auth = EspAuthModeToWiFiAuth(ap_info.authmode);
+						SafeStrncpy(response->ssid, (const char*)ap_info.ssid, sizeof(response->ssid));
+					}
+					else
+					{
+						wifi_sta_list_t sta_list;
+						memset(&sta_list, 0, sizeof(sta_list));
+						esp_wifi_ap_get_sta_list(&sta_list);
+						response->numClients = sta_list.num;
+
+						wifi_config_t ap_cfg;
+						esp_wifi_get_config(WIFI_IF_AP, &ap_cfg);
+						response->auth = EspAuthModeToWiFiAuth(ap_cfg.ap.authmode);
+						SafeStrncpy(response->ssid, (const char*)ap_cfg.ap.ssid, sizeof(response->ssid));
+					}
+
+					tcpip_adapter_ip_info_t ip_info;
+					tcpip_adapter_get_ip_info(runningAsStation ? TCPIP_ADAPTER_IF_STA : TCPIP_ADAPTER_IF_AP, &ip_info);
+					response->ipAddress = ip_info.ip.addr;
+					response->netmask = ip_info.netmask.addr;
+					response->gateway = ip_info.gw.addr;
+
+					uint8_t pChan;
+					wifi_second_chan_t sChan;
+					esp_wifi_get_channel(&pChan, &sChan);
+					response->channel = pChan;
+
+					switch (sChan)
+					{
+					case WIFI_SECOND_CHAN_NONE:
+						response->ht = static_cast<uint8_t>(HTMode::HT20);
+						break;
+
+					case WIFI_SECOND_CHAN_ABOVE:
+						response->ht = static_cast<uint8_t>(HTMode::HT40_ABOVE);
+						break;
+
+					case WIFI_SECOND_CHAN_BELOW:
+						response->ht = static_cast<uint8_t>(HTMode::HT40_BELOW);
+						break;
+
+					default:
+						break;
+					}
+
+					uint8_t EspWiFiPhyMode = 0;
+					esp_wifi_get_protocol(runningAsStation ? WIFI_IF_STA : WIFI_IF_AP, &EspWiFiPhyMode);
+
+					if (EspWiFiPhyMode | WIFI_PROTOCOL_11N) {
+						response->phyMode = static_cast<int>(EspWiFiPhyMode::N);
+					} else if (EspWiFiPhyMode | WIFI_PROTOCOL_11G) {
+						response->phyMode = static_cast<int>(EspWiFiPhyMode::G);
+					} else if (EspWiFiPhyMode | WIFI_PROTOCOL_11B) {
+						response->phyMode = static_cast<int>(EspWiFiPhyMode::B);
+					}
+
 				}
 
-				response->zero1 = 0;
-				response->zero2 = 0;
+				response->freeHeap = esp_get_free_heap_size();
+
 #ifdef ESP8266
 				response->vcc = esp_wifi_get_vdd33();
 #else
 				response->vcc = 0;
 #endif
-				WirelessConfigurationData wp;
-				wirelessConfigMgr->GetSsid(currentSsid, wp);
-				SafeStrncpy(response->versionText, firmwareVersion, sizeof(response->versionText));
-				SafeStrncpy(response->hostName, webHostName, sizeof(response->hostName));
-				SafeStrncpy(response->ssid, wp.ssid, sizeof(response->ssid));
-#ifdef ESP8266
-				response->clockReg = REG(SPI_CLOCK(MSPI));
-#else
-				response->clockReg = SPI_LL_GET_HW(MSPI)->clock.val;
-#endif
+
 				SendResponse(sizeof(NetworkStatusResponse));
 			}
 			break;
@@ -1252,50 +1358,7 @@ void ProcessRequest()
 							d.phymode = EspWiFiPhyMode::B;
 						}
 
-						switch (ap.authmode)
-						{
-						case WIFI_AUTH_OPEN:
-							d.auth = WiFiAuth::OPEN;
-							break;
-
-						case WIFI_AUTH_WEP:
-							d.auth = WiFiAuth::WEP;
-							break;
-
-						case WIFI_AUTH_WPA_PSK:
-							d.auth = WiFiAuth::WPA_PSK;
-							break;
-
-						case WIFI_AUTH_WPA2_PSK:
-							d.auth = WiFiAuth::WPA2_PSK;
-							break;
-
-						case WIFI_AUTH_WPA_WPA2_PSK:
-							d.auth = WiFiAuth::WPA_WPA2_PSK;
-							break;
-
-						case WIFI_AUTH_WPA2_ENTERPRISE:
-							d.auth = WiFiAuth::WPA2_ENTERPRISE;
-							break;
-
-						case WIFI_AUTH_WPA3_PSK:
-							d.auth = WiFiAuth::WPA3_PSK;
-							break;
-
-						case WIFI_AUTH_WPA2_WPA3_PSK:
-							d.auth = WiFiAuth::WPA2_WPA3_PSK;
-							break;
-
-#ifndef ESP8266
-						case WIFI_AUTH_WAPI_PSK:
-							d.auth = WiFiAuth::WAPI_PSK;
-							break;
-#endif
-
-						default:
-							d.auth = WiFiAuth::UNKNOWN;
-							break;
-						}
+						d.auth = EspAuthModeToWiFiAuth(ap.authmode);
 					}
 
 				}
@@ -1514,7 +1577,15 @@ void ProcessRequest()
 			default:
 				break;
 			}
-			delay(100);
+
+			while (currentState != WiFiState::idle)
+			{
+				delay(100);
+			}
+
+			usingDhcpc = false;
+			numWifiReconnects = 0;
+			currentSsid = -1;
 			break;
 
 		case NetworkCommand::networkStartScan:

--- a/src/include/MessageFormats.h
+++ b/src/include/MessageFormats.h
@@ -90,7 +90,6 @@ struct MessageHeaderSamToEsp
 	static const uint8_t FlagPush = 0x02;
 };
 
-
 enum class EspWiFiPhyMode {
 	B = 1,
 	G = 2,
@@ -230,8 +229,14 @@ struct MessageHeaderEspToSam
 
 static_assert(sizeof(MessageHeaderSamToEsp) == sizeof(MessageHeaderEspToSam), "Message header sizes don't match");
 
-// Now the message data formats
+enum class HTMode : uint8_t
+{
+	HT20 = 0,			// 20 Mhz channel width
+	HT40_ABOVE,			// 40 Mhz channel width, extra channel above primary channel
+	HT40_BELOW			// 40 Mhz channel width, extra channel below primary channel
+};
 
+// Now the message data formats
 struct NetworkStatusResponse
 {
 	// No need to include the network state here because that is included in the header
@@ -251,6 +256,17 @@ struct NetworkStatusResponse
 	char ssid[SsidLength];			// SSID of the router we are connected to, or our own SSDI
 	char hostName[64];				// name of the access point we are connected to, or our own access point name
 	uint32_t clockReg;				// the SPI clock register
+
+	// Added at version 2.1
+	uint32_t netmask;				// subnet mask of the network connected to/created
+	uint32_t gateway;				// endorsed gateway IP of the network connected to/created
+	uint32_t numReconnects;			// number of reconnections since the explicit STA connection by RRF
+	uint8_t  usingDhcpc;			// if the current ip, netmask, gateway was obtained through DHCP as a client
+	WiFiAuth auth;					// authentication method of the AP connected to in STA mode, in AP mode always WPA2-Personal
+	uint8_t channel : 4,			// primary channel used by the STA/AP connection
+			ht:	2,					// HT20, HT40 above, HT40 below
+			zero3: 2;				// unused, set to zero
+	uint8_t zero4;					// unused, set to zero
 };
 
 /* The reset reasons are coded as follows (see resetReasonTexts in file WiFiInterface.cpp in the RepRapFirmware project):


### PR DESCRIPTION
This PR adds fields to the NetworkStatusResponse needed for the RRF object model. This also fixes some errors in setting the values of the fields.